### PR TITLE
Added support for Android N

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ For more information about FFmpeg, see https://www.ffmpeg.org/download.html#get-
 
 ## How to to build
 
-* Install [autotools](http://www.jattcode.com/installing-autoconf-automake-libtool-on-mac-osx-mountain-lion/).
+* Install [autotools](http://www.jattcode.com/installing-autoconf-automake-libtool-on-mac-osx-mountain-lion/) (or just run ./autotools.sh).
 * Clone the repo.
 * Define where you want NDK installed. DONT use any symbolic links in `$DIR_NDK`.
 

--- a/autotools.sh
+++ b/autotools.sh
@@ -1,0 +1,14 @@
+curl -OL http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
+tar -xzf autoconf-2.69.tar.gz 
+cd autoconf-2.69
+./configure && make && sudo make install
+ 
+curl -OL http://ftpmirror.gnu.org/automake/automake-1.14.tar.gz
+tar -xzf automake-1.14.tar.gz
+cd automake-1.14
+./configure && make && sudo make install
+ 
+curl -OL http://ftpmirror.gnu.org/libtool/libtool-2.4.2.tar.gz
+tar -xzf libtool-2.4.2.tar.gz
+cd libtool-2.4.2
+./configure && make && sudo make install

--- a/autotools.sh
+++ b/autotools.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+# Run this script to quickly install Autoconf, Automake & Libtool on Mac OSX.
+
 curl -OL http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
 tar -xzf autoconf-2.69.tar.gz 
 cd autoconf-2.69

--- a/build_ffmpeg.sh
+++ b/build_ffmpeg.sh
@@ -32,22 +32,22 @@ if [ "$1" = "--init" ]; then
 
     printf "NDK\n"
 
-    if [ ! -f android-ndk32-r10-darwin-x86_64.tar.bz2 ]; then
-        printf "    downloading\n"
-        curl "http://dl.google.com/android/ndk/android-ndk32-r10-darwin-x86_64.tar.bz2" \
-            -o android-ndk32-r10-darwin-x86_64.tar.bz2 \
+    if [ ! -f android-ndk-r12b-darwin-x86_64.zip ]; then
+        printf "    downloading r12b for mac\n"
+        curl "https://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip" \
+            -o android-ndk-r12b-darwin-x86_64.zip \
             >> ${LOG_FILE} 2>&1
     fi
 
-    printf "    extracting\n"
-    tar xvzf android-ndk32-r10-darwin-x86_64.tar.bz2 \
+    printf "    unzipping\n"
+    unzip android-ndk-r12b-darwin-x86_64.zip \
         >> ${LOG_FILE} 2>&1
 
     printf "    moving to ${DIR_NDK}\n"
     rm -rf ${DIR_NDK} || true
     mkdir -p ${DIR_NDK} \
         >> ${LOG_FILE} 2>&1
-    mv android-ndk-r10/* ${DIR_NDK} \
+    mv android-ndk-r12b/* ${DIR_NDK} \
         >> ${LOG_FILE} 2>&1
 
     printf "    done\n"
@@ -58,11 +58,11 @@ if [ "$1" = "--init" ]; then
     cd ${DIR_NDK}/sources \
         >> ${LOG_FILE} 2>&1
 
-    printf "    downloading yasm\n"
+    printf "    cloning yasm\n"
     git clone --progress git://github.com/yasm/yasm.git \
         >> ${LOG_FILE} 2>&1
 
-    printf "    downloading ogg\n"
+    printf "    cloning ogg\n"
     git clone --progress git://git.xiph.org/mirrors/ogg.git \
         >> ${LOG_FILE} 2>&1
 
@@ -79,11 +79,11 @@ if [ "$1" = "--init" ]; then
     mv libvorbis-1.3.4 libvorbis \
         >> ${LOG_FILE} 2>&1
 
-    printf "    downloading vpx\n"
-    (git clone --progress http://chromium.googlesource.com/webm/libvpx.git libvpx) \
+    printf "    cloning vpx\n"
+    (git clone --progress https://chromium.googlesource.com/webm/libvpx.git libvpx) \
         >> ${LOG_FILE} 2>&1
 
-    printf "    downloading ffmpeg\n"
+    printf "    cloning ffmpeg\n"
     (git clone --progress git://source.ffmpeg.org/ffmpeg.git ffmpeg) \
         >> ${LOG_FILE} 2>&1
 
@@ -131,7 +131,7 @@ DIR_SYSROOT=${DIR_NDK}/platforms/android-${LEVEL}/arch-${CPU}/usr
 
 if [ ! -d "${DIR_SYSROOT}/bin" ]; then
     printf "TOOLCHAIN\n"
-    TOOLCHAIN=${TOOLCHAIN_PREFIX}-4.8
+    TOOLCHAIN=${TOOLCHAIN_PREFIX}-4.9
 
     printf "    generating\n"
     ${DIR_NDK}/build/tools/make-standalone-toolchain.sh \
@@ -310,7 +310,7 @@ if [ "$1" = "--reset" ] || [ "$1" = "--init" ]; then
     printf "    resetting\n"
     git checkout -- . \
         >> ${LOG_FILE} 2>&1
-    git checkout release/2.4 \
+    git checkout release/3.0 \
         >> ${LOG_FILE} 2>&1
     git pull \
         >> ${LOG_FILE} 2>&1


### PR DESCRIPTION
Android removed the option of running native with text relocations: https://android.googlesource.com/platform/bionic/+/e4ad91f86a47b39612e030a162f4793cb3421d31%5E%21/

This commit simply bumps FFmpeg from 2.4 to 3.0, starts using NDK revision 12b, and fixes a few things that changed in different repos and should allow building again. It also includes a fix for #3.

Also added script to install Auto-tools.
