### PR TITLE
Improved .gitignore to consider changes made when bumping to FFmpeg v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 ndk/
+autoconf-*
+*.tar.gz
+*.zip
 *.tar.bz2
 build_ffmpeg.log
 .DS_STORE


### PR DESCRIPTION
Small changes to make sure downloaded/generated outputs don't bother the developer showing up on git.